### PR TITLE
修正個人頁面跳轉

### DIFF
--- a/src/components/Admin/AdminTweetsList.jsx
+++ b/src/components/Admin/AdminTweetsList.jsx
@@ -59,11 +59,7 @@ function TweetItem({ tweet, onDelete }) {
           </span>
         </div>
         <div className="tweet-content">
-          <p>
-            {tweet.description.length >= 50
-              ? tweet.description + "..."
-              : tweet.description}
-          </p>
+          <p>{tweet.description}</p>
         </div>
       </div>
       <IconDelete

--- a/src/components/Profile/ProfileList.jsx
+++ b/src/components/Profile/ProfileList.jsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from "react";
+import { useTweet } from "context/TweetContext";
+import { useReply } from "context/ReplyContext";
+
+// api
+import {
+  getUserTweetListAPI,
+  getUserReplyListAPI,
+  getUserLikeListAPI,
+} from "api/main";
+
+// style
+import "styles/profile.css";
+
+// components
+
+import TweetNavbar from "components/Profile/TweetNavbar";
+import TweetList from "components/Main/TweetList.jsx";
+import ReplyList from "components/Main/ReplyList";
+import LoadingMes from "components/LoadingMes";
+
+// import { useReply } from "context/ReplyContext";
+
+const navbarData = [
+  { title: "推文", view: "tweet" },
+  { title: "回覆", view: "reply" },
+  { title: "喜歡", view: "like" },
+];
+
+// function
+function ProfileList({ apiId }) {
+  console.log("apiId", apiId);
+  let dataId = apiId;
+  const [currentView, setCurrentView] = useState("tweet");
+  const { tweetList, setTweetList } = useTweet();
+  const { replyList, setReplyList } = useReply();
+
+  const [loading, setLoading] = useState(true);
+
+  let partialView;
+  if (currentView === "tweet") {
+    // 推文分頁
+    partialView = <TweetList list_data={tweetList} />;
+  } else if (currentView === "reply") {
+    // 回覆分頁
+    partialView = <ReplyList list_data={replyList} />;
+  } else if (currentView === "like") {
+    //喜歡分頁
+    partialView = <TweetList list_data={tweetList} />;
+  }
+
+  // 取得使用者推文
+  useEffect(() => {
+    const getListData = async (dataId) => {
+      try {
+        setLoading(true);
+        if (currentView === "tweet") {
+          const result = await getUserTweetListAPI(dataId); // 取得推文
+          if (result?.status === 200) {
+            setTweetList(result?.data);
+            setLoading(false);
+            return;
+          }
+        } else if (currentView === "reply") {
+          const result = await getUserReplyListAPI(dataId); // 取得回覆
+          if (result?.status === 200) {
+            setReplyList(result?.data);
+            setLoading(false);
+            return;
+          }
+        } else if (currentView === "like") {
+          const result = await getUserLikeListAPI(dataId); // 取得喜歡
+          if (result?.status === 200) {
+            const new_data = result?.data.map((item) => {
+              return item?.Tweet;
+            });
+            setTweetList(new_data);
+            setLoading(false);
+            return;
+          }
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    };
+    getListData(dataId);
+  }, [dataId, currentView]);
+
+  // 更換分頁
+  function onViewChange(view) {
+    setCurrentView(view);
+    async function getListData(followMode) {
+      try {
+        setLoading(true);
+        setCurrentView(view);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+    getListData(view);
+  }
+
+  return (
+    <>
+      <TweetNavbar
+        navbarData={navbarData}
+        currentView={currentView}
+        onViewChange={onViewChange}
+      />
+
+      {/* 分頁 */}
+      {loading ? <LoadingMes /> : partialView}
+    </>
+  );
+}
+export default ProfileList;

--- a/src/components/Profile/ProfileModal.jsx
+++ b/src/components/Profile/ProfileModal.jsx
@@ -11,7 +11,7 @@ import "styles/profileModal.css";
 import { ReactComponent as IconClose } from "assets/icons/close.svg";
 import { ReactComponent as IconAddPhoto } from "assets/icons/addphoto.svg";
 
-export default function ReplyModal({ onModalToggle }) {
+export default function ReplyModal({ onModalToggle, reRender }) {
   const [name, setName] = useState("");
   const [introduction, setIntroduction] = useState("");
   const [avatar, setAvatar] = useState(null); // 處理avatar預覽
@@ -98,7 +98,7 @@ export default function ReplyModal({ onModalToggle }) {
     if (result.status === 200) {
       setNotiMessage({ type: "success", message: "資料已更新！" });
       setIsAlert(true);
-      onModalToggle(false, true);
+      onModalToggle(false, !reRender);
     }
   }
 
@@ -107,7 +107,7 @@ export default function ReplyModal({ onModalToggle }) {
       <div
         className="gray_panel"
         onClick={() => {
-          onModalToggle(false, false);
+          onModalToggle(false, reRender);
         }}
       ></div>
       <div className="modal_panel">
@@ -116,7 +116,7 @@ export default function ReplyModal({ onModalToggle }) {
             <span
               className="close_btn"
               onClick={() => {
-                onModalToggle(false, false);
+                onModalToggle(false, reRender);
               }}
             >
               <IconClose />

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -1,37 +1,19 @@
 import { useState, useEffect } from "react";
 import { NavLink, useParams } from "react-router-dom";
 import { useAuth } from "context/AuthContext";
-import { useTweet } from "context/TweetContext";
 
 // api
 import { getUserDataAPI } from "api/userProfile";
-import {
-  getUserTweetListAPI,
-  getUserReplyListAPI,
-  getUserLikeListAPI,
-} from "api/main";
-
 // style
 import "styles/profile.css";
 
 // components
 import ProfileGuide from "components/Profile/ProfileGuide";
 import Interactive from "components/Profile/Interactive";
-import TweetNavbar from "components/Profile/TweetNavbar";
-import TweetList from "components/Main/TweetList.jsx";
-import ReplyList from "components/Main/ReplyList";
 import ProfileModal from "components/Profile/ProfileModal.jsx";
-
-import { useReply } from "context/ReplyContext";
 
 import { ReactComponent as IconAvatar } from "assets/icons/avatar.svg";
 import default_cover from "assets/images/default_user_cover.jpg";
-
-const navbarData = [
-  { title: "推文", view: "tweet" },
-  { title: "回覆", view: "reply" },
-  { title: "喜歡", view: "like" },
-];
 
 // function
 function ProfilePage() {
@@ -41,10 +23,7 @@ function ProfilePage() {
   const selfId = Number(currentMember.id);
   const [modal_toggle, setModalToggle] = useState(false);
   const [reRender, setReRender] = useState(true);
-  const { tweetList, setTweetList } = useTweet();
-  const { replyList, setReplyList } = useReply();
   const [profileData, setProfileData] = useState({});
-  const [currentView, setCurrentView] = useState("tweet");
 
   //判斷顯示
   const identity = selfId === apiId ? "self" : "other";
@@ -71,66 +50,6 @@ function ProfilePage() {
       }
     }
   }, [isAuthenticated, logout, apiId, reRender]);
-
-  //判斷分頁
-  let partialView;
-  if (currentView === "tweet") {
-    // 推文分頁
-    partialView = <TweetList list_data={tweetList} />;
-  } else if (currentView === "reply") {
-    // 回覆分頁
-    partialView = <ReplyList list_data={replyList} />;
-  } else {
-    //喜歡分頁
-    partialView = <TweetList list_data={tweetList} />;
-  }
-
-  async function getUserTweetList() {
-    const result = await getUserTweetListAPI(apiId);
-    if (result.status === 200) {
-      setTweetList(result.data);
-    }
-  }
-
-  // 取得使用者推文
-  useEffect(() => {
-    if (reRender) {
-      getUserTweetList();
-      setReRender(false);
-      setCurrentView("tweet");
-    }
-  }, [apiId, reRender]);
-
-  // 更換分頁
-  function onViewChange(view) {
-    // 取得個人回覆 function
-    async function getUserReplyList() {
-      const result = await getUserReplyListAPI(apiId);
-      if (result.status === 200) {
-        setReplyList(result.data);
-      }
-    }
-
-    //取得喜歡的推文 function
-    async function getUserLikeList() {
-      const result = await getUserLikeListAPI(apiId);
-      if (result.status === 200) {
-        const new_data = result.data.map((item) => {
-          return item.Tweet;
-        });
-        setTweetList(new_data);
-      }
-    }
-
-    if (view === "reply") {
-      getUserReplyList(); // 取得個人回覆
-    } else if (view === "like") {
-      getUserLikeList(); // 取得喜歡的推文
-    } else {
-      getUserTweetList(); // 取得個人推文
-    }
-    setCurrentView(view);
-  }
 
   function onModalToggle(is_active, rerender) {
     setModalToggle(is_active);
@@ -224,14 +143,6 @@ function ProfilePage() {
             </div>
           </div>
         </div>
-        <TweetNavbar
-          navbarData={navbarData}
-          currentView={currentView}
-          onViewChange={onViewChange}
-        />
-
-        {/* 分頁 */}
-        {partialView}
       </div>
 
       {modal_toggle && <ProfileModal onModalToggle={onModalToggle} />}

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -11,7 +11,7 @@ import "styles/profile.css";
 import ProfileGuide from "components/Profile/ProfileGuide";
 import Interactive from "components/Profile/Interactive";
 import ProfileModal from "components/Profile/ProfileModal.jsx";
-
+import ProfileList from "components/Profile/ProfileList";
 import { ReactComponent as IconAvatar } from "assets/icons/avatar.svg";
 import default_cover from "assets/images/default_user_cover.jpg";
 
@@ -31,12 +31,6 @@ function ProfilePage() {
 
   // 取得使用者資訊(還要再改)
   useEffect(() => {
-    // console.log("identity", identity);
-    // console.log("apiId", apiId);
-    // console.log("pathname", pathname);
-    console.log("identity", identity);
-    console.log("apiId", apiId);
-    console.log("pathname", pathname);
     if (!isAuthenticated) {
       return logout();
     } else {
@@ -147,6 +141,7 @@ function ProfilePage() {
             </div>
           </div>
         </div>
+        <ProfileList apiId={apiId} />
       </div>
 
       {modal_toggle && (

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { NavLink, useParams } from "react-router-dom";
+import { useLocation, NavLink, useParams } from "react-router-dom";
 import { useAuth } from "context/AuthContext";
 
 // api
@@ -18,11 +18,12 @@ import default_cover from "assets/images/default_user_cover.jpg";
 // function
 function ProfilePage() {
   const { isAuthenticated, logout, currentMember } = useAuth();
+  const { pathname } = useLocation();
   const { user_id } = useParams();
   const apiId = Number(user_id);
   const selfId = Number(currentMember.id);
   const [modal_toggle, setModalToggle] = useState(false);
-  const [reRender, setReRender] = useState(true);
+  const [reRender, setReRender] = useState(false);
   const [profileData, setProfileData] = useState({});
 
   //判斷顯示
@@ -30,6 +31,12 @@ function ProfilePage() {
 
   // 取得使用者資訊(還要再改)
   useEffect(() => {
+    // console.log("identity", identity);
+    // console.log("apiId", apiId);
+    // console.log("pathname", pathname);
+    console.log("identity", identity);
+    console.log("apiId", apiId);
+    console.log("pathname", pathname);
     if (!isAuthenticated) {
       return logout();
     } else {
@@ -44,12 +51,9 @@ function ProfilePage() {
           console.log(err);
         }
       };
-      if (reRender) {
-        getProfileData();
-        setReRender(false);
-      }
+      getProfileData();
     }
-  }, [isAuthenticated, logout, apiId, reRender]);
+  }, [isAuthenticated, logout, pathname, apiId, reRender]);
 
   function onModalToggle(is_active, rerender) {
     setModalToggle(is_active);
@@ -145,7 +149,9 @@ function ProfilePage() {
         </div>
       </div>
 
-      {modal_toggle && <ProfileModal onModalToggle={onModalToggle} />}
+      {modal_toggle && (
+        <ProfileModal onModalToggle={onModalToggle} reRender={reRender} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
1.拆解proflePage ，取得個人資料和清單，分成兩個元件。
2.修改上傳個人資料，利用!reRender反轉狀態來完成，修改為!reRender，未修改保持reRender。
3.清單殘影設置loading來解決。
4.本地端測試個人頁面跳轉OK，可以切換不同使用者和清單資料。
5.修正後台推文清單的字數呈現，後端回傳的字數已有篩過，前端不再做處理。